### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/ks_bms_ble/ks_bms_ble.cpp
+++ b/components/ks_bms_ble/ks_bms_ble.cpp
@@ -9,8 +9,7 @@
 #define ADDR_STR(x) (x).c_str()
 #endif
 
-namespace esphome {
-namespace ks_bms_ble {
+namespace esphome::ks_bms_ble {
 
 static const char *const TAG = "ks_bms_ble";
 
@@ -981,5 +980,4 @@ std::string KsBmsBle::fet_control_status_to_balancer_status_text_(uint16_t fet_c
   return "Idle";
 }
 
-}  // namespace ks_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ks_bms_ble

--- a/components/ks_bms_ble/ks_bms_ble.h
+++ b/components/ks_bms_ble/ks_bms_ble.h
@@ -13,8 +13,7 @@
 #include <esp_gattc_api.h>
 #endif
 
-namespace esphome {
-namespace ks_bms_ble {
+namespace esphome::ks_bms_ble {
 
 #ifdef USE_ESP32
 namespace espbt = esphome::esp32_ble_tracker;
@@ -465,5 +464,4 @@ class KsBmsBle :
   bool check_bit_(uint16_t mask, uint16_t flag) { return (mask & flag) == flag; }
 };
 
-}  // namespace ks_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ks_bms_ble

--- a/components/ks_bms_ble/number/ks_number.cpp
+++ b/components/ks_bms_ble/number/ks_number.cpp
@@ -2,8 +2,7 @@
 #include "../ks_bms_ble.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ks_bms_ble {
+namespace esphome::ks_bms_ble {
 
 static const char *const TAG = "ks_bms_ble.number";
 
@@ -16,5 +15,4 @@ void KsNumber::control(float value) {
   }
 }
 
-}  // namespace ks_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ks_bms_ble

--- a/components/ks_bms_ble/number/ks_number.h
+++ b/components/ks_bms_ble/number/ks_number.h
@@ -3,8 +3,7 @@
 #include "esphome/components/number/number.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ks_bms_ble {
+namespace esphome::ks_bms_ble {
 
 class KsBmsBle;
 
@@ -26,5 +25,4 @@ class KsNumber : public number::Number, public Component {
   float offset_{0.0f};
 };
 
-}  // namespace ks_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ks_bms_ble

--- a/components/ks_bms_ble/switch/ks_switch.cpp
+++ b/components/ks_bms_ble/switch/ks_switch.cpp
@@ -2,8 +2,7 @@
 #include "../ks_bms_ble.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ks_bms_ble {
+namespace esphome::ks_bms_ble {
 
 static const char *const TAG = "ks_bms_ble.switch";
 
@@ -15,5 +14,4 @@ void KsSwitch::write_state(bool state) {
   }
 }
 
-}  // namespace ks_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ks_bms_ble

--- a/components/ks_bms_ble/switch/ks_switch.h
+++ b/components/ks_bms_ble/switch/ks_switch.h
@@ -3,8 +3,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ks_bms_ble {
+namespace esphome::ks_bms_ble {
 
 class KsBmsBle;
 
@@ -21,5 +20,4 @@ class KsSwitch : public switch_::Switch, public Component {
   uint8_t holding_register_;
 };
 
-}  // namespace ks_bms_ble
-}  // namespace esphome
+}  // namespace esphome::ks_bms_ble


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.