### PR TITLE
Fix redundant string initialization

### DIFF
--- a/components/ks_bms_ble/ks_bms_ble.cpp
+++ b/components/ks_bms_ble/ks_bms_ble.cpp
@@ -955,7 +955,7 @@ void KsBmsBle::publish_state_(text_sensor::TextSensor *text_sensor, const std::s
 
 std::string KsBmsBle::bitmask_to_string_(const char *const messages[], const uint8_t &messages_size,
                                          const uint16_t &mask) {
-  std::string values = "";
+  std::string values;
   if (mask) {
     for (int i = 0; i < messages_size; i++) {
       if (mask & (1 << i)) {


### PR DESCRIPTION
Remove redundant empty string initialization (`= ""`) flagged by `readability-redundant-string-init`. `std::string` default-constructs to an empty string.